### PR TITLE
Alteração no menu principal do Pensando

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,10 @@
         {
             "type": "git",
             "url": "https://github.com/pensandoodireito/debatepublico-tema"
+        },
+        {
+          "type": "git",
+          "url": "https://github.com/pensandoodireito/intercambio-tema"
         }
     ],
     "require": {
@@ -61,12 +65,14 @@
         "pensandoodireito/participacao-tema" : "dev-master",
         "pensandoodireito/debatepublico-tema" : "dev-master",
         "pensandoodireito/pensandoodireito-network-functions" : "dev-master",
+        "pensandoodireito/intercambio-tema" : "dev-master",
         "pensandoodireito/wp-side-comments" : "dev-master",
         "ethymos/delibera" : "dev-master",
         "wpackagist-plugin/rich-text-tags": "1.7.3",
         "wpackagist-plugin/json-rest-api": "1.1.1",
         "wpackagist-plugin/contact-form-plugin": "3.89",
         "wpackagist-plugin/email-newsletter": "20.12",
+        "wpackagist-plugin/social-share-button": "2.1",
         "fancyguy/webroot-installer": "1.0.0",
         "composer/installers": "~1.0"
     },

--- a/scripts/delete_tag.sh
+++ b/scripts/delete_tag.sh
@@ -43,6 +43,10 @@ cd ../debatepublico-tema
 
 delete_tag $1 debatepublico-tema
 
+cd ../intercambio-tema
+
+delete_tag $1 intercambio-tema
+
 cd ../../plugins/pensandoodireito-network-functions
 
 delete_tag $1 pensandoodireito-network-functions

--- a/scripts/generate_tag.sh
+++ b/scripts/generate_tag.sh
@@ -53,6 +53,10 @@ cd ../debatepublico-tema
 
 gerar_tag_master debatepublico-tema $1
 
+cd ../intercambio-tema
+
+gerar_tag_master intercambio-tema $1
+
 cd ../../plugins/pensandoodireito-network-functions
 
 gerar_tag_master pensandoodireito-network-functions $1

--- a/scripts/set_tag.sh
+++ b/scripts/set_tag.sh
@@ -9,6 +9,7 @@ fi
 function fetch_settag {
 
 	git fetch --all
+	git reset HEAD --hard
 	git checkout $1
 
 }

--- a/scripts/set_tag.sh
+++ b/scripts/set_tag.sh
@@ -38,6 +38,10 @@ cd ../debatepublico-tema
 
 fetch_settag $1
 
+cd ../intercambio-tema
+
+fetch_settag $1
+
 cd ../../plugins/pensandoodireito-network-functions
 
 fetch_settag $1

--- a/scripts/update_masters.sh
+++ b/scripts/update_masters.sh
@@ -39,6 +39,10 @@ cd ../debatepublico-tema
 
 update_master debatepublico-tema $1
 
+cd ../intercambio-tema
+
+update_master intercambio-tema $1
+
 cd ../../plugins/pensandoodireito-network-functions
 
 update_master pensandoodireito-network-functions $1


### PR DESCRIPTION
Tive alguns problemas com Vagrant e só consegui baixar o projeto usando o Composer. 

O problema do menu aparece ao inserir novas páginas. Para resolver, coloquei os links "inline", para não sair do limite da faixa marrom. Para as resoluções menores (menores que 780px), criei um "media query" que coloca os links em "block", aparecendo um abaixo do outro.

Segue o link com uma imagem do o menu com problema: http://www.elizeohamu.com.br/wp-content/uploads/temp/problema.jpg

Agora as imagens com o problema resolvido:
http://www.elizeohamu.com.br/wp-content/uploads/temp/pg-inicial.jpg
http://www.elizeohamu.com.br/wp-content/uploads/temp/pg-menu-open.jpg
http://www.elizeohamu.com.br/wp-content/uploads/temp/pg-width-780.jpg

Como não consegui comitar o arquivo alterado, disponibilizei o arquivo que alterei: 
http://www.elizeohamu.com.br/wp-content/uploads/temp/site-global.css

Quanto às melhorias, trabalharia um pouco o tamanho das fontes e o posicionamento de alguns elementos. No exemplo do desafio, mudei também os links que estão abaixo da faixa marrom, pois também apareciam desconfigurados.